### PR TITLE
Ignore Syntax Warnings from PiPER SDK

### DIFF
--- a/src/piper_cli/__main__.py
+++ b/src/piper_cli/__main__.py
@@ -1,7 +1,10 @@
 import argparse
 import time
+import warnings
 
 from piper_sdk import C_PiperInterface_V2
+
+warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"^piper_sdk(\.|$)")
 
 
 def main() -> None:


### PR DESCRIPTION
This pull request resolves #3 by ignoring syntax warnings from the `piper-sdk` package.