### PR TITLE
Modify Enable Command to Wait for Arm to Be Fully Enabled

### DIFF
--- a/src/piper_cli/commands/enable.py
+++ b/src/piper_cli/commands/enable.py
@@ -7,12 +7,27 @@ from piper_sdk import C_PiperInterface_V2
 def command_enable(_: argparse.Namespace) -> None:
     piper = C_PiperInterface_V2()
     piper.ConnectPort()
+    piper.EnableArm(7)
 
-    while True:
-        piper.EnableArm(7)
-        piper.MotionCtrl_2(0x01, 0x01, 100, 0x00)
-        piper.JointCtrl(0, 0, 0, 0, 0, 0)
-        time.sleep(0.05)
+    enabled = False
+    while not enabled:
+        time.sleep(0.1)
+        info = piper.GetArmLowSpdInfoMsgs()
+        enabled = all(
+            [
+                info.motor_1.foc_status.driver_enable_status,
+                info.motor_2.foc_status.driver_enable_status,
+                info.motor_3.foc_status.driver_enable_status,
+                info.motor_4.foc_status.driver_enable_status,
+                info.motor_5.foc_status.driver_enable_status,
+                info.motor_6.foc_status.driver_enable_status,
+            ]
+        )
+
+    piper.MotionCtrl_2(0x01, 0x01, 100, 0x00)
+    time.sleep(0.5)
+
+    piper.JointCtrl(0, 0, 0, 0, 0, 0)
 
 
 __all__ = ["command_enable"]


### PR DESCRIPTION
This pull request resolves #7 by modifying the `enable` command to wait for the PiPER arm to be fully enabled before moving it to the zero position.