### PR TITLE
Add Argument for Specifying CAN Interface

### DIFF
--- a/src/piper_cli/__main__.py
+++ b/src/piper_cli/__main__.py
@@ -13,6 +13,9 @@ def main() -> None:
 
     enable_parser = subparsers.add_parser("enable", help="enable the PiPER arm")
     enable_parser.set_defaults(func=command_enable)
+    enable_parser.add_argument(
+        "can_interface", nargs="?", default="can0", help="CAN interface to use"
+    )
 
     args = parser.parse_args()
     args.func(args)

--- a/src/piper_cli/commands/enable.py
+++ b/src/piper_cli/commands/enable.py
@@ -4,8 +4,8 @@ import time
 from piper_sdk import C_PiperInterface_V2
 
 
-def command_enable(_: argparse.Namespace) -> None:
-    piper = C_PiperInterface_V2()
+def command_enable(args: argparse.Namespace) -> None:
+    piper = C_PiperInterface_V2(args.can_interface)
     piper.ConnectPort()
     piper.EnableArm(7)
 


### PR DESCRIPTION
This pull request resolves #9 by adding a new `can_interface` argument in the `enable` command for specifying CAN interface to use for controlling the PiPER arm.