### PR TITLE
Add Command for Disabling Arm

### DIFF
--- a/src/piper_cli/__main__.py
+++ b/src/piper_cli/__main__.py
@@ -1,7 +1,7 @@
 import argparse
 import warnings
 
-from .commands import command_enable
+from .commands import command_disable, command_enable
 
 warnings.filterwarnings("ignore", category=SyntaxWarning, module=r"^piper_sdk(\.|$)")
 
@@ -10,6 +10,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(prog="piper")
     parser.add_argument("-v", "--version", action="version", version="0.1.0")
     subparsers = parser.add_subparsers(required=True)
+
+    disable_parser = subparsers.add_parser("disable", help="disable the PiPER arm")
+    disable_parser.set_defaults(func=command_disable)
+    disable_parser.add_argument(
+        "can_interface", nargs="?", default="can0", help="CAN interface to use"
+    )
 
     enable_parser = subparsers.add_parser("enable", help="enable the PiPER arm")
     enable_parser.set_defaults(func=command_enable)

--- a/src/piper_cli/commands/__init__.py
+++ b/src/piper_cli/commands/__init__.py
@@ -1,3 +1,4 @@
+from .disable import command_disable
 from .enable import command_enable
 
-__all__ = ["command_enable"]
+__all__ = ["command_disable", "command_enable"]

--- a/src/piper_cli/commands/disable.py
+++ b/src/piper_cli/commands/disable.py
@@ -8,8 +8,8 @@ def command_disable(args: argparse.Namespace) -> None:
     piper = C_PiperInterface_V2(args.can_interface)
     piper.ConnectPort()
 
-    piper.MotionCtrl_2(0x01, 0x01, 100, 0x00)
-    time.sleep(0.5)
+    piper.MotionCtrl_2(0x01, 0x01, 20, 0x00)
+    time.sleep(0.1)
 
     positions = [0, 0, 0, 0, 17000, 0]
     piper.JointCtrl(*positions)

--- a/src/piper_cli/commands/disable.py
+++ b/src/piper_cli/commands/disable.py
@@ -1,0 +1,36 @@
+import argparse
+import time
+
+from piper_sdk import C_PiperInterface_V2
+
+
+def command_disable(args: argparse.Namespace) -> None:
+    piper = C_PiperInterface_V2(args.can_interface)
+    piper.ConnectPort()
+
+    piper.MotionCtrl_2(0x01, 0x01, 100, 0x00)
+    time.sleep(0.5)
+
+    positions = [0, 0, 0, 0, 17000, 0]
+    piper.JointCtrl(*positions)
+
+    done = False
+    tolerance = 1000
+    while not done:
+        time.sleep(0.1)
+        state = piper.GetArmJointMsgs().joint_state
+        done = all(
+            [
+                abs(state.joint_1 - positions[0]) <= tolerance,
+                abs(state.joint_2 - positions[1]) <= tolerance,
+                abs(state.joint_3 - positions[2]) <= tolerance,
+                abs(state.joint_4 - positions[3]) <= tolerance,
+                abs(state.joint_5 - positions[4]) <= tolerance,
+                abs(state.joint_6 - positions[5]) <= tolerance,
+            ]
+        )
+
+    piper.DisableArm(7)
+
+
+__all__ = ["command_disable"]

--- a/src/piper_cli/commands/enable.py
+++ b/src/piper_cli/commands/enable.py
@@ -24,8 +24,8 @@ def command_enable(args: argparse.Namespace) -> None:
             ]
         )
 
-    piper.MotionCtrl_2(0x01, 0x01, 100, 0x00)
-    time.sleep(0.5)
+    piper.MotionCtrl_2(0x01, 0x01, 20, 0x00)
+    time.sleep(0.1)
 
     piper.JointCtrl(0, 0, 0, 0, 0, 0)
 


### PR DESCRIPTION
This pull request resolves #11 by adding a command that moves the PiPER arm into a safe position before disabling it. This change also reduces the joint speed and wait time when enabling or disabling the arm.
